### PR TITLE
Upgrade Alpine 3.7 musl to fix CVE-2019-14697

### DIFF
--- a/kinetic/bare/Dockerfile
+++ b/kinetic/bare/Dockerfile
@@ -19,6 +19,8 @@ RUN mkdir -p /usr/lib/python2.7/site-packages/ \
 
 ENV ROS_DISTRO kinetic
 
+RUN apk upgrade --no-cache musl>=1.1.18-r4  # CVE-2019-14697
+
 COPY ros_entrypoint.sh /
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["sh"]

--- a/kinetic/ros-core/Dockerfile
+++ b/kinetic/ros-core/Dockerfile
@@ -20,6 +20,8 @@ RUN mkdir -p /usr/lib/python2.7/site-packages/ \
 
 ENV ROS_DISTRO kinetic
 
+RUN apk upgrade --no-cache musl>=1.1.18-r4  # CVE-2019-14697
+
 COPY ros_entrypoint.sh /
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["sh"]


### PR DESCRIPTION
ref: https://git.alpinelinux.org/aports/commit/?id=c07f44bfbb6aa1722bfc72f99ef20e2fd2a61ee4