### PR TITLE
Use actions token to deploy image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CONTAINER_REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |


### PR DESCRIPTION
instead of PAT

Write access from this repository is allowed by [the container registry](https://github.com/alpine-ros/alpine-ros/pkgs/container/alpine-ros) setting.