### PR TITLE
Add version constraints for py3-rosdistro

### DIFF
--- a/noetic-3.17/ros-core/.template.Dockerfile
+++ b/noetic-3.17/ros-core/.template.Dockerfile
@@ -5,5 +5,6 @@ RUN apk add --no-cache py3-rosdep \
   && sed -i -e 's/ros\/rosdistro\/master/alpine-ros\/rosdistro\/alpine-custom-apk/' /etc/ros/rosdep/sources.list.d/20-default.list
 
 RUN apk add --no-cache \
+  py3-rosdistro\>=0.9.0 \
   ros-noetic-catkin\>=0.8.9 \
   ros-noetic-ros-core\>=1.5.0

--- a/noetic-3.17/ros-core/.template.Dockerfile
+++ b/noetic-3.17/ros-core/.template.Dockerfile
@@ -1,10 +1,11 @@
 @@IMPORT noetic-3.17/bare/Dockerfile
 
-RUN apk add --no-cache py3-rosdep \
+RUN apk add --no-cache \
+    py3-rosdep \
+    py3-rosdistro\>=0.9.0 \
   && rosdep init \
   && sed -i -e 's/ros\/rosdistro\/master/alpine-ros\/rosdistro\/alpine-custom-apk/' /etc/ros/rosdep/sources.list.d/20-default.list
 
 RUN apk add --no-cache \
-  py3-rosdistro\>=0.9.0 \
   ros-noetic-catkin\>=0.8.9 \
   ros-noetic-ros-core\>=1.5.0

--- a/noetic-3.17/ros-core/Dockerfile
+++ b/noetic-3.17/ros-core/Dockerfile
@@ -24,7 +24,9 @@ COPY ros_entrypoint.sh /
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["sh"]
 
-RUN apk add --no-cache py3-rosdep \
+RUN apk add --no-cache \
+    py3-rosdep \
+    py3-rosdistro\>=0.9.0 \
   && rosdep init \
   && sed -i -e 's/ros\/rosdistro\/master/alpine-ros\/rosdistro\/alpine-custom-apk/' /etc/ros/rosdep/sources.list.d/20-default.list
 


### PR DESCRIPTION
This is to make sure the fix from https://github.com/seqsense/aports-ros-experimental/pull/777 is included in the docker image.