### PR TITLE
Drop Melodic and Noetic-3.11 build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,10 +13,6 @@ jobs:
     strategy:
       matrix:
         env:
-          - DOCKERFILE_PATH=melodic/bare
-          - DOCKERFILE_PATH=melodic/ros-core
-          - DOCKERFILE_PATH=noetic/bare
-          - DOCKERFILE_PATH=noetic/ros-core
           - DOCKERFILE_PATH=noetic-3.14/bare
           - DOCKERFILE_PATH=noetic-3.14/ros-core
           - DOCKERFILE_PATH=noetic-3.17/bare

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker image of ROS (Robot Operating System) on Alpine Linux
 ## News
 
 ### April 2023
-`melodic` (Melodic EOL on May 2023) and `noetic-3.11` (Alpine 3.11 EOL on May 2020) is dropped.
+`melodic` (Melodic EOL on May 2023) and `noetic-3.11` (Alpine 3.11 EOL on May 2020) are dropped.
 These images are still available but no longer updated. It is highly recommended to update to `noetic-3.14` or `noetic-3.17`.
 
 ## Registry

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # Alpine ROS Docker Images
 Docker image of ROS (Robot Operating System) on Alpine Linux
 
+## News
+
+### April 2023
+`melodic` (Melodic EOL on May 2023) and `noetic-3.11` (Alpine 3.11 EOL on May 2020) is dropped.
+These images are still available but no longer updated. It is highly recommended to update to `noetic-3.14` or `noetic-3.17`.
+
 ## Registry
 Images are available on GitHub Container Registry
 ```
-docker pull ghcr.io/alpine-ros/alpine-ros:noetic-bare
-docker pull ghcr.io/alpine-ros/alpine-ros:noetic-ros-core
+docker pull ghcr.io/alpine-ros/alpine-ros:noetic-3.17-bare
+docker pull ghcr.io/alpine-ros/alpine-ros:noetic-3.17-ros-core
 ```


### PR DESCRIPTION
Melodic is EOL-ed
Alpine 3.11 is EOL-ed in 2020

### Related PRs
- https://github.com/alpine-ros/alpine-ros/pull/27
- https://github.com/alpine-ros/ros-abuild-docker/pull/161
- https://github.com/seqsense/aports-ros-updater/pull/68
- https://github.com/seqsense/aports-ros-experimental/pull/819