### PR TITLE
Recommend docker compose over docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker pull ghcr.io/alpine-ros/alpine-ros:noetic-3.17-ros-core
 ```
 
 ## Demo
-Basic pub/sub using alpine-ros. You can run below `docker-compose.yml` by `docker-compose up`.
+Basic pub/sub using alpine-ros. You can run below `docker-compose.yml` by `docker compose up`.
 ### ROS 1
 ```docker-compose.yml
 # docker-compose.yml


### PR DESCRIPTION
* Compose V1 will be EOL after June 2023
* https://docs.docker.com/compose/migrate/

 Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/)