### PR TITLE
Use https for custom repositories instead of http

### DIFF
--- a/humble-3.17/bare/Dockerfile
+++ b/humble-3.17/bare/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.17.3
 
 ENV ALPINE_VERSION=3.17
 
-RUN echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories \
-  && echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/ros/humble" >> /etc/apk/repositories \
+RUN echo "https://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories \
+  && echo "https://alpine-ros.seqsense.org/v${ALPINE_VERSION}/ros/humble" >> /etc/apk/repositories \
   && echo $'-----BEGIN PUBLIC KEY-----\n\
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnSO+a+rIaTorOowj3c8e\n\
 5St89puiGJ54QmOW9faDsTcIWhycl4bM5lftp8IdcpKadcnaihwLtMLeaHNJvMIP\n\

--- a/humble-3.17/ros-core/Dockerfile
+++ b/humble-3.17/ros-core/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.17.3
 
 ENV ALPINE_VERSION=3.17
 
-RUN echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories \
-  && echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/ros/humble" >> /etc/apk/repositories \
+RUN echo "https://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories \
+  && echo "https://alpine-ros.seqsense.org/v${ALPINE_VERSION}/ros/humble" >> /etc/apk/repositories \
   && echo $'-----BEGIN PUBLIC KEY-----\n\
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnSO+a+rIaTorOowj3c8e\n\
 5St89puiGJ54QmOW9faDsTcIWhycl4bM5lftp8IdcpKadcnaihwLtMLeaHNJvMIP\n\

--- a/noetic-3.17/bare/Dockerfile
+++ b/noetic-3.17/bare/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.17.3
 
 ENV ALPINE_VERSION=3.17
 
-RUN echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories \
-  && echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/ros/noetic" >> /etc/apk/repositories \
+RUN echo "https://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories \
+  && echo "https://alpine-ros.seqsense.org/v${ALPINE_VERSION}/ros/noetic" >> /etc/apk/repositories \
   && echo $'-----BEGIN PUBLIC KEY-----\n\
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnSO+a+rIaTorOowj3c8e\n\
 5St89puiGJ54QmOW9faDsTcIWhycl4bM5lftp8IdcpKadcnaihwLtMLeaHNJvMIP\n\

--- a/noetic-3.17/ros-core/Dockerfile
+++ b/noetic-3.17/ros-core/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.17.3
 
 ENV ALPINE_VERSION=3.17
 
-RUN echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories \
-  && echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/ros/noetic" >> /etc/apk/repositories \
+RUN echo "https://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories \
+  && echo "https://alpine-ros.seqsense.org/v${ALPINE_VERSION}/ros/noetic" >> /etc/apk/repositories \
   && echo $'-----BEGIN PUBLIC KEY-----\n\
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnSO+a+rIaTorOowj3c8e\n\
 5St89puiGJ54QmOW9faDsTcIWhycl4bM5lftp8IdcpKadcnaihwLtMLeaHNJvMIP\n\


### PR DESCRIPTION
Both issues reported in https://github.com/alpine-ros/alpine-ros/issues/31 and https://github.com/alpine-ros/alpine-ros/issues/32 were fixed by using `https` instead of `http` so defaulting to `https` probably makes sense. In this PR the change is only applied to `noetic-3.17` and `humble-3.17` as the other ones are no longer supported. 