### PR TITLE
noetic-3.20: install ros-dev by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Docker image of ROS (Robot Operating System) on Alpine Linux
 
 ## News
 
+### July 2024
+`noetic-3.20` is added.
+Since `noetic-3.20`, development files and dependencies are split into `-dev` subpackages.
+Users can remove `-dev` packages by `apk add !ros-dev`.
+
 ### January 2024
 `noetic-3.14` (Alpine 3.14 EOL on May 2023) is dropped. The corresponding images are still available but no longer updated.
 It is highly recommended to update to `noetic-3.17`.

--- a/noetic-3.20/bare/Dockerfile
+++ b/noetic-3.20/bare/Dockerfile
@@ -23,6 +23,10 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO noetic
 
+# Install -dev subpackages by default for compatibility.
+# It can be opted-out by `apk add !ros-dev`
+RUN apk add --no-cache ros-dev
+
 COPY ros_entrypoint.sh /
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["sh"]

--- a/noetic-3.20/ros-core/Dockerfile
+++ b/noetic-3.20/ros-core/Dockerfile
@@ -24,6 +24,10 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO noetic
 
+# Install -dev subpackages by default for compatibility.
+# It can be opted-out by `apk add !ros-dev`
+RUN apk add --no-cache ros-dev
+
 COPY ros_entrypoint.sh /
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["sh"]


### PR DESCRIPTION
- https://github.com/alpine-ros/ros-abuild-docker/issues/24
- requires https://github.com/seqsense/aports-ros-experimental/pull/970 to pass the tests

Install ros-dev to the base image by default to keep the default behavior.
Users can install packages without dev files by
`apk add !ros-dev ...`