### PR TITLE
Enable to build humble-3.23

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,8 @@ jobs:
         env:
           - DOCKERFILE_PATH=humble-3.20/bare
           - DOCKERFILE_PATH=humble-3.20/ros-core
+          - DOCKERFILE_PATH=humble-3.23/bare
+          - DOCKERFILE_PATH=humble-3.23/ros-core
           - DOCKERFILE_PATH=jazzy-3.20/bare
           - DOCKERFILE_PATH=jazzy-3.20/ros-core
           - DOCKERFILE_PATH=jazzy-3.23/bare


### PR DESCRIPTION
Missing in https://github.com/alpine-ros/alpine-ros/pull/51